### PR TITLE
Made the expansion of the test assemblies itemgroup delayed

### DIFF
--- a/Build.config
+++ b/Build.config
@@ -10,9 +10,13 @@
     <BuildOutput Include="Src\Exude\bin\Release\Grean.Exude.XML" />
   </ItemGroup>
   <ItemGroup>
-    <TestAssemblies Include="**\bin\Release\*UnitTests*.dll" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectToBuild Include="Src\*.sln" />
   </ItemGroup>
+  <!-- Expand build output files AFTER the build has run. 
+       Note that the Build Task MUST BE defined by the file that includes this file. -->
+  <Target Name="GetTestAssemblies" DependsOnTargets="Build">
+    <ItemGroup>
+      <TestAssemblies Include="**\bin\Release\*UnitTests*.dll" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/BuildRelease.msbuild
+++ b/BuildRelease.msbuild
@@ -23,8 +23,8 @@
     <MSBuild Projects="@(ProjectToBuild)" Properties="Configuration=Release" />
   </Target>
 
-  <!--Test-->
-  <Target Name="Test" DependsOnTargets="Build">
+  <!--Test. Note that the GetTestAssemblies Task MUST BE defined in the Build.config file. -->
+  <Target Name="Test" DependsOnTargets="GetTestAssemblies">
     <xunit Assemblies="@(TestAssemblies)" />
   </Target>
 


### PR DESCRIPTION
so it is not executed until after the Build Task. This enables the build
to run on a clean directory, as well as supporting re-runs on directories
with existing test binaries from previous runs.

This solves the technical problem of first-time runs, but I'm not sure if the requirement of having a Target in the Build.config file is acceptable? It's a bit implicit, but allows for the project specific directory specs to stay in the  Build.config file. Otherwise, the GetTestAssemblies Target can be moved to the BuildRelease.msbuild file, but then we lose the ability to keep all project-specific values inside the Build.config file.
