### PR TITLE
Specified minimum required xUnit.net version in .nuspec file

### DIFF
--- a/NuGetSpecs/Grean.Exude.nuspec
+++ b/NuGetSpecs/Grean.Exude.nuspec
@@ -6,6 +6,9 @@
     <title>Exude</title>
     <authors>Grean ApS</authors>
     <owners>Grean ApS</owners>
+    <dependencies>
+      <dependency id="xunit" version="1.9.2" />
+    </dependencies>
     <projectUrl>https://github.com/GreanTech/Exude</projectUrl>
     <licenseUrl>https://github.com/GreanTech/Exude/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
Adds a `dependency` element in the _Grean.Exude.nuspec_ file specifing the minimum required xUnit.net version.

Addresses issue #12.
