### PR TITLE
Added support for Action delegates in TestCase class

### DIFF
--- a/Src/Exude.UnitTests/Scenario.cs
+++ b/Src/Exude.UnitTests/Scenario.cs
@@ -14,6 +14,10 @@ namespace Grean.Exude.UnitTests
             yield return new TestCase(_ => Assert.Equal(1, 1));
             yield return new TestCase(_ => Assert.Equal(2, 2));
             yield return new TestCase(_ => Assert.Equal(3, 3));
+
+            yield return new TestCase(() => Assert.Equal(1, 1));
+            yield return new TestCase(() => Assert.Equal(2, 2));
+            yield return new TestCase(() => Assert.Equal(3, 3));
         }
 
         [FirstClassTests]

--- a/Src/Exude.UnitTests/TestCaseTests.cs
+++ b/Src/Exude.UnitTests/TestCaseTests.cs
@@ -31,6 +31,18 @@ namespace Grean.Exude.UnitTests
         }
 
         [Fact]
+        public void AdaptedTestActionIsCorrect()
+        {
+            var verified = false;
+            Action testAction = () => verified = true;
+            var sut = new TestCase(testAction);
+
+            sut.TestAction(new object());
+
+            Assert.True(verified);
+        }
+
+        [Fact]
         public void ConstructWithNullTestActionThrows()
         {
             Assert.Throws<ArgumentNullException>(

--- a/Src/Exude.UnitTests/TestCaseTests.cs
+++ b/Src/Exude.UnitTests/TestCaseTests.cs
@@ -43,10 +43,17 @@ namespace Grean.Exude.UnitTests
         }
 
         [Fact]
-        public void ConstructWithNullTestActionThrows()
+        public void ConstructWithNullTestActionOfObjectThrows()
         {
             Assert.Throws<ArgumentNullException>(
                 () => new TestCase((Action<object>)null));
+        }
+
+        [Fact]
+        public void ConstructWithNullTestActionThrows()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new TestCase((Action)null));
         }
 
         [Fact]

--- a/Src/Exude.UnitTests/TestCaseTests.cs
+++ b/Src/Exude.UnitTests/TestCaseTests.cs
@@ -34,7 +34,7 @@ namespace Grean.Exude.UnitTests
         public void ConstructWithNullTestActionThrows()
         {
             Assert.Throws<ArgumentNullException>(
-                () => new TestCase(null));
+                () => new TestCase((Action<object>)null));
         }
 
         [Fact]

--- a/Src/Exude/TestCase.cs
+++ b/Src/Exude/TestCase.cs
@@ -19,6 +19,37 @@ namespace Grean.Exude
     {
         private Action<object> testAction;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestCase"/> class.
+        /// </summary>
+        /// <param name="testAction">
+        /// The test action to be invoked when the test is executed.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// When this test case is exececuted, the
+        /// <paramref name="testAction" /> is invoked.
+        /// </para>
+        /// <para>
+        /// The test action constructor argument is subsequently available as
+        /// the <see cref="TestAction" /> property.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// This simple example returns three test cases that all pass:
+        /// <code><![CDATA[[FirstClassTests]
+        /// public static IEnumerable<ITestCase> YieldFirstClassTests()
+        /// {
+        ///     yield return new TestCase(() => Assert.Equal(1, 1));
+        ///     yield return new TestCase(() => Assert.Equal(2, 2));
+        ///     yield return new TestCase(() => Assert.Equal(3, 3));
+        /// }]]>
+        /// </code>
+        /// </example>
+        /// <exception cref="System.ArgumentNullException">
+        /// <paramref name="testAction" /> is <see langword="null" />
+        /// </exception>
+        /// <seealso cref="TestAction" />
         public TestCase(Action testAction)
             : this(TestCase.ConvertToAction<object>(testAction))
         {

--- a/Src/Exude/TestCase.cs
+++ b/Src/Exude/TestCase.cs
@@ -19,6 +19,10 @@ namespace Grean.Exude
     {
         private Action<object> testAction;
 
+        public TestCase(Action testAction)
+        {
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCase"/> class.
         /// </summary>

--- a/Src/Exude/TestCase.cs
+++ b/Src/Exude/TestCase.cs
@@ -20,6 +20,7 @@ namespace Grean.Exude
         private Action<object> testAction;
 
         public TestCase(Action testAction)
+            : this(new Action<object>(_ => testAction()))
         {
         }
 

--- a/Src/Exude/TestCase.cs
+++ b/Src/Exude/TestCase.cs
@@ -20,7 +20,7 @@ namespace Grean.Exude
         private Action<object> testAction;
 
         public TestCase(Action testAction)
-            : this(new Action<object>(_ => testAction()))
+            : this(TestCase.ConvertToAction<object>(testAction))
         {
         }
 
@@ -96,6 +96,14 @@ namespace Grean.Exude
         public Action<object> TestAction
         {
             get { return this.testAction; }
+        }
+
+        private static Action<T> ConvertToAction<T>(Action testAction)
+        {
+            if (testAction == null)
+                throw new ArgumentNullException("testAction");
+
+            return new Action<T>(_ => testAction());
         }
     }
 


### PR DESCRIPTION
This could probably address #16.

Please notice that, in the files changed, I didn't have to return a different `ITestCommand` instance as [suggested in the description](https://github.com/GreanTech/Exude/issues/16#issue-29510346).

The following tests passed by only adapting `Action` to `Action<object>` in the `TestCase` class:

```
[FirstClassTests]
public static IEnumerable<ITestCase> YieldFirstClassTests()
{
    yield return new TestCase(() => Assert.Equal(1, 1));
    yield return new TestCase(() => Assert.Equal(2, 2));
    yield return new TestCase(() => Assert.Equal(3, 3));
}
```
